### PR TITLE
Avoid duplicated reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This actions uses the pull request workflow to prevent the merging of a pull req
 
 Instead, consider the same example, the action is triggered by `pull_request`'s types `opened` and `labeled`, then if a pull request is opened without adding a valid label at the time of open the pull request, then that will trigger a check that will succeed, but will crate a pull request review, requesting for changes. The pull request review will prevent the merging of the pull request (if the option `Require pull request reviews before merging` is enabled in the repository) in this case. Adding a valid label to the repository will then trigger a **new** action which will succeed as well, but in this case it will create a new pull request review, approving the pull request. After this the pull request can be merge.
 
+When this action runs, it will look for the previous review done by this action. If it finds it, it will check if it was approved or if it requested changes, and it will avoid to repeat the same request again. However, if the option `Dismiss stale pull request approvals when new commits are pushed` is enabled in the repository, previous review will be automatically dismissed and therefore this check will failed, and a new request will always be generated.
+
 **Note**: if you want to use the `Require pull request reviews before merging` to require reviews approval before merging pull request, then you need to increase the number of `Required approving reviewers` by one, as this check will do an approval when a valid label is present. So, for example, if you want at least one reviewer approval, the set this value to 2.
 
 ## Inputs

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -59,6 +59,9 @@ pr = repo.get_pull(pr_number)
 # Get the pull request labels
 pr_labels = pr.get_labels()
 
+# Get the list of reviews
+pr_reviews = pr.get_reviews()
+
 # This is a list of valid label found in the pull request
 pr_valid_labels = []
 
@@ -67,6 +70,27 @@ pr_valid_labels = []
 for label in pr_labels:
     if label.name in valid_labels:
         pr_valid_labels.append(label.name)
+
+# Look for the last review done by this module. The variable
+# 'was_approved' will be set to True/False if the last review
+# done was approved/requested changes; if there was not a
+# previous review the variable will be set to 'None'.
+was_approved = None
+for review in pr_reviews.reversed:
+    # Reviews done by this modules uses a login name
+    # 'github-actions[bot]'
+    if review.user.login == 'github-actions[bot]':
+        if review.state == 'APPROVED':
+            # The last review was approved
+            was_approved = True
+        elif review.state == 'CHANGES_REQUESTED':
+            # The last review requested changes
+            was_approved = False
+
+        # Break this loop after the last review is found.
+        # If no review was done, 'was_approved' will remain
+        # as 'None'.
+        break
 
 # Check if there were at least one valid label
 # Note: In both cases we exit without an error code and let the check to succeed. This is because GitHub

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -99,7 +99,8 @@ for review in pr_reviews.reversed:
 # Instead, we will create a pull request review, marked with 'REQUEST_CHANGES' when no valid label was found.
 # This will prevent merging the pull request until a valid label is added, which will trigger this check again
 # and will create a new pull request review, but in this case marked as 'APPROVE'
-
+# Note 2: We check for the status of the previous review done by this module. If a previous review exists, and
+# it state and the current state are the same, a new request won't be generated.
 
 if len(pr_valid_labels):
     # If there were valid labels, create a pull request review, approving it

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -108,8 +108,7 @@ if len(pr_valid_labels):
     if was_approved == True:
         print(f'The last review was already approved')
     else:
-        pr.create_review(body = 'This pull request contains a valid label.',
-                         event = 'APPROVE')
+        pr.create_review(event = 'APPROVE')
 else:
     # If there were not valid labels, then create a pull request review, requesting changes
     print(f'Error! This pull request does not contain any of the valid labels: {valid_labels}')

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -80,7 +80,6 @@ for review in pr_reviews.reversed:
     # Reviews done by this modules uses a login name
     # 'github-actions[bot]'
     if review.user.login == 'github-actions[bot]':
-        print(f'Last review found, its state is {review.state}')
         if review.state == 'APPROVED':
             # The last review was approved
             was_approved = True

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -102,7 +102,6 @@ for review in pr_reviews.reversed:
 # Note 2: We check for the status of the previous review done by this module. If a previous review exists, and
 # it state and the current state are the same, a new request won't be generated.
 
-
 if len(pr_valid_labels):
     # If there were valid labels, create a pull request review, approving it
     print(f'Success! This pull request contains the following valid labels: {pr_valid_labels}')

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -100,6 +100,7 @@ for review in pr_reviews.reversed:
 # This will prevent merging the pull request until a valid label is added, which will trigger this check again
 # and will create a new pull request review, but in this case marked as 'APPROVE'
 
+
 if len(pr_valid_labels):
     # If there were valid labels, create a pull request review, approving it
     print(f'Success! This pull request contains the following valid labels: {pr_valid_labels}')

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -102,6 +102,7 @@ for review in pr_reviews.reversed:
 # Note 2: We check for the status of the previous review done by this module. If a previous review exists, and
 # it state and the current state are the same, a new request won't be generated.
 
+
 if len(pr_valid_labels):
     # If there were valid labels, create a pull request review, approving it
     print(f'Success! This pull request contains the following valid labels: {pr_valid_labels}')

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -80,6 +80,7 @@ for review in pr_reviews.reversed:
     # Reviews done by this modules uses a login name
     # 'github-actions[bot]'
     if review.user.login == 'github-actions[bot]':
+        print(f'Last review found, its state is {review.state}')
         if review.state == 'APPROVED':
             # The last review was approved
             was_approved = True

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -101,13 +101,23 @@ for review in pr_reviews.reversed:
 # and will create a new pull request review, but in this case marked as 'APPROVE'
 
 if len(pr_valid_labels):
-    # If there were valid labels, then create a pull request request review, approving it
+    # If there were valid labels, create a pull request review, approving it
     print(f'Success! This pull request contains the following valid labels: {pr_valid_labels}')
-    pr.create_review(body = 'This pull request contains a valid label.',
-                     event = 'APPROVE')
+
+    # If the last review done was approved, then don't approved it again
+    if was_approved == True:
+        print(f'The last review was already approved')
+    else:
+        pr.create_review(body = 'This pull request contains a valid label.',
+                         event = 'APPROVE')
 else:
     # If there were not valid labels, then create a pull request review, requesting changes
     print(f'Error! This pull request does not contain any of the valid labels: {valid_labels}')
-    pr.create_review(body = 'This pull request does not contain a valid label. '
-                            f'Please add one of the following labels: `{valid_labels}`',
-                     event = 'REQUEST_CHANGES')
+
+    # If the last review done requested changes, then don't request changes again
+    if was_approved == False:
+        print(f'The last review already requested changes')
+    else:
+        pr.create_review(body = 'This pull request does not contain a valid label. '
+                                f'Please add one of the following labels: `{valid_labels}`',
+                         event = 'REQUEST_CHANGES')


### PR DESCRIPTION
This PR avoid duplicates reviews: if the last review done by this modules was approved/requested changes, and the new state it is the same, the module won't redo the same action. 