### PR TITLE
Allow PRs from forks 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 on:
-  pull_request:
+  pull_request_target:
    types: [opened, labeled, unlabeled, synchronize]
 
 jobs:
@@ -15,3 +15,4 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           valid-labels: 'bug, enhancement'
+          pull-request-number: '${{ github.event.pull_request.number }}'

--- a/README.md
+++ b/README.md
@@ -5,21 +5,21 @@
 
 ## Description
 
-This action will verify if a pull request has at least one label from a set of valid labels. The set of valid valid labels is defined by the user and passed as an input argument.
+This action will verify if a pull request has at least one label from a set of valid labels. The set of valid labels is defined by the user and passed as an input argument.
 
-If the pull request does not contain a label from the set of valid labels, then the action will create a pull request review using the event `REQUEST_CHANGES`. On the other hand, if a valid label is present in the pull request, the action will create a pull request review using the event `APPROVE` instead. In both of these cases the exit code will be `0`, and the GitHub check will success.
+If the pull request does not contain a label from the set of valid labels, then the action will create a pull request review using the event `REQUEST_CHANGES`. On the other hand, if a valid label is present in the pull request, the action will instead create a pull request review using the event `APPROVE`. In both of these cases the exit code will be `0`, and the GitHub check will succeed.
 
-This actions uses the pull request workflow to prevent the merging of a pull request without a valid label, instead of the status of the GitHub checks. The reason for this is that GitHub workflows will run independent checks for different trigger conditions, instead of grouping them together. For example, consider that action is triggered by `pull_request`'s types `opened` and `labeled`, then if a pull request is opened without adding a valid label at the time of open the pull request, then that will trigger a check that should failed; however, adding later a valid label to the pull request will just trigger a **new** check which should succeed, but the first check will remain in the failed state, and the pull request merge will be blocked (if the option `Require status checks to pass before merging` is enabled in the repository).
+This action uses the pull request workflow to prevent the merging of a pull request without a valid label, instead of the status of the GitHub checks. The reason for this is that GitHub workflows will run independent checks for different trigger conditions, instead of grouping them together. For example, consider that the action is triggered by `pull_request`'s types `opened` and `labeled`, then if a pull request is opened without adding a valid label at the time of creating the pull request, then that event will trigger a check that should fail; however, adding later a valid label to the pull request will just trigger a **new** check which will succeed, but the first check will remain in the failed state (and the pull request merge will be blocked if the option `Require status checks to pass before merging` is enabled in the repository).
 
-Instead, consider the same example, the action is triggered by `pull_request`'s types `opened` and `labeled`, then if a pull request is opened without adding a valid label at the time of open the pull request, then that will trigger a check that will succeed, but will crate a pull request review, requesting for changes. The pull request review will prevent the merging of the pull request (if the option `Require pull request reviews before merging` is enabled in the repository) in this case. Adding a valid label to the repository will then trigger a **new** action which will succeed as well, but in this case it will create a new pull request review, approving the pull request. After this the pull request can be merge.
+Instead, consider the same example, the action is triggered by `pull_request`'s types `opened` and `labeled`, then if a pull request is opened without adding a valid label at the time of creating the pull request, then that event will trigger a check that will succeed, but will crate a pull request review, requesting for changes. The pull request review will prevent the merging of the pull request (if the option `Require pull request reviews before merging` is enabled in the repository) in this case. Adding a valid label to the repository will then trigger a **new** action which will succeed as well, but in this case it will create a new pull request review, approving the pull request. After this, the pull request can be merged.
 
-When this action runs, it will look for the previous review done by this action. If it finds it, it will check if it was approved or if it requested changes, and it will avoid to repeat the same request again. However, if the option `Dismiss stale pull request approvals when new commits are pushed` is enabled in the repository, previous review will be automatically dismissed and therefore this check will failed, and a new request will always be generated.
+When this action runs, it will look for the previous review done by this action. If it finds it, it will check if it was approved or if it requested changes, and it will not repeat the same request again. However, if the option `Dismiss stale pull request approvals when new commits are pushed` is enabled in the repository, previous review will be automatically dismissed and therefore this check will fail, and a new request will always be generated.
 
-**Note**: if you want to use the `Require pull request reviews before merging` to require reviews approval before merging pull request, then you need to increase the number of `Required approving reviewers` by one, as this check will do an approval when a valid label is present. So, for example, if you want at least one reviewer approval, the set this value to 2.
+**Note**: if you want to use the `Require pull request reviews before merging` to require reviews approval before merging pull requests, then you need to increase the number of `Required approving reviewers` by one, as this check will do an approval when a valid label is present. So, for example, if you want at least one reviewer approval, then set this value to 2.
 
 ## Note when working with forks
 
-When a pull request in opened from a forked repository, Github actions run with read-only permissions, and so the action won't be able to create a pull request review.
+When a pull request is opened from a forked repository, Github actions run with read-only permissions, and so the action won't be able to create a pull request review.
 
 Fortunately, Github recently added a new trigger event `pull_request_target` which behaves in an almost identical way to the `pull_request` event, but the action runs in the base of the pull request and will therefore have write permission. However, as the action runs in the base of the pull request, the pull request number is not available in the environmental variables, and must therefore be passed as an input argument. Please refer to the example usage section for more details.
 
@@ -31,21 +31,21 @@ Fortunately, Github recently added a new trigger event `pull_request_target` whi
 
 ### `valid-labels`
 
-**Required** A list of valid labels. It must be a quoted string, with label separated by colons. For example: `'bug, enhancement'`
+**Required** A list of valid labels. It must be a quoted string, with label separated by commas. For example: `'bug, enhancement'`
 
 ### `pull-request-number`
 
-**Optional** The pull request number, available in the github context: `${{ github.event.pull_request.number }}`. This number is automatically extracted from the environmental variables when the action triggers on `pull_request`. However, when the trigger used is `pull_request_target`, then this input needs to be used.
+**Optional** The pull request number, available in the github context: `${{ github.event.pull_request.number }}`. This number is automatically extracted from the environmental variables when the action triggers on `pull_request`. However, when the trigger used is `pull_request_target`, then this input must be used.
 
 ## Example usage
 
 ### If you want to allow PRs from forks
 
-If you want to allow PRs from anywhere, including forks, then you can use this example. This instruction will work even if your not going to work with forks.
+If you want to allow PRs from anywhere, including forks, then you can use this example. These instructions will work even if you are not going to work with forks.
 
 In your workflow YAML file add these steps:
 ```yaml
-uses: jesusvasquez333/verify-pr-label-action@v1.2.0
+uses: jesusvasquez333/verify-pr-label-action@v1.3.0
 with:
     github-token: '${{ secrets.GITHUB_TOKEN }}'
     valid-labels: 'bug, enhancement'
@@ -59,9 +59,9 @@ on:
    types: [opened, labeled, unlabeled, synchronize]
 ```
 
-### If you plan to only open PRs same repository
+### If you plan to only open PRs from the same repository
 
-If you plan to open PR only from the same repository, you can use this example, which requires one less input value. This however won't work if you open a PR from a fork.
+If you plan to open PR only from the same repository, you can use this example, which requires one less input value. However, this won't work if you open a PR from a fork.
 
 In your workflow YAML file add this step:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ When this action runs, it will look for the previous review done by this action.
 
 When a pull request in opened from a forked repository, Github actions run with read-only permissions, and so the action won't be able to create a pull request review.
 
-Fortunately, Github recently added a new trigger event `pull_request_target` which behaves in an almost identical way to the `pull_request` event, but the action runs in the base of the pull request and will therefore have write permission. However, as the action runs in the base of the pull request, the pull request number is not available in the environmental variables, and must therefor passed as an input argument. Please refer to the example usage section for more details.
+Fortunately, Github recently added a new trigger event `pull_request_target` which behaves in an almost identical way to the `pull_request` event, but the action runs in the base of the pull request and will therefore have write permission. However, as the action runs in the base of the pull request, the pull request number is not available in the environmental variables, and must therefore be passed as an input argument. Please refer to the example usage section for more details.
 
 ## Inputs
 
@@ -35,13 +35,15 @@ Fortunately, Github recently added a new trigger event `pull_request_target` whi
 
 ### `pull-request-number`
 
-**Optional** The pull request number, available in the github context: `${{ github.event.pull_request.number }}`. This number is automatically extracted from the environmental variables when the action trigger on `pull_request`. However, when the trigger used is `pull_request_target`, then this number needs to be passed here.
+**Optional** The pull request number, available in the github context: `${{ github.event.pull_request.number }}`. This number is automatically extracted from the environmental variables when the action triggers on `pull_request`. However, when the trigger used is `pull_request_target`, then this input needs to be used.
 
 ## Example usage
 
-### Allowing PR from forks
+### If you want to allow PRs from forks
 
-In your workflow YAML file add this step:
+If you want to allow PRs from anywhere, including forks, then you can use this example. This instruction will work even if your not going to work with forks.
+
+In your workflow YAML file add these steps:
 ```yaml
 uses: jesusvasquez333/verify-pr-label-action@v1.2.0
 with:
@@ -57,11 +59,13 @@ on:
    types: [opened, labeled, unlabeled, synchronize]
 ```
 
-### Allowing PR only from the same repository
+### If you plan to only open PRs same repository
+
+If you plan to open PR only from the same repository, you can use this example, which requires one less input value. This however won't work if you open a PR from a fork.
 
 In your workflow YAML file add this step:
 ```yaml
-uses: jesusvasquez333/verify-pr-label-action@v1.2.0
+uses: jesusvasquez333/verify-pr-label-action@v1.3.0
 with:
     github-token: '${{ secrets.GITHUB_TOKEN }}'
     valid-labels: 'bug, enhancement'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/162d73a2aff6478081cdc34ee9ee7b6e)](https://app.codacy.com/manual/jesusvasquez333/verify-pr-label-action?utm_source=github.com&utm_medium=referral&utm_content=jesusvasquez333/verify-pr-label-action&utm_campaign=Badge_Grade_Dashboard)
 
+
+## Description
+
 This action will verify if a pull request has at least one label from a set of valid labels. The set of valid valid labels is defined by the user and passed as an input argument.
 
 If the pull request does not contain a label from the set of valid labels, then the action will create a pull request review using the event `REQUEST_CHANGES`. On the other hand, if a valid label is present in the pull request, the action will create a pull request review using the event `APPROVE` instead. In both of these cases the exit code will be `0`, and the GitHub check will success.
@@ -14,6 +17,12 @@ When this action runs, it will look for the previous review done by this action.
 
 **Note**: if you want to use the `Require pull request reviews before merging` to require reviews approval before merging pull request, then you need to increase the number of `Required approving reviewers` by one, as this check will do an approval when a valid label is present. So, for example, if you want at least one reviewer approval, the set this value to 2.
 
+## Note when working with forks
+
+When a pull request in opened from a forked repository, Github actions run with read-only permissions, and so the action won't be able to create a pull request review.
+
+Fortunately, Github recently added a new trigger event `pull_request_target` which behaves in an almost identical way to the `pull_request` event, but the action runs in the base of the pull request and will therefore have write permission. However, as the action runs in the base of the pull request, the pull request number is not available in the environmental variables, and must therefor passed as an input argument. Please refer to the example usage section for more details.
+
 ## Inputs
 
 ### `github-token`
@@ -24,7 +33,31 @@ When this action runs, it will look for the previous review done by this action.
 
 **Required** A list of valid labels. It must be a quoted string, with label separated by colons. For example: `'bug, enhancement'`
 
+### `pull-request-number`
+
+**Optional** The pull request number, available in the github context: `${{ github.event.pull_request.number }}`. This number is automatically extracted from the environmental variables when the action trigger on `pull_request`. However, when the trigger used is `pull_request_target`, then this number needs to be passed here.
+
 ## Example usage
+
+### Allowing PR from forks
+
+In your workflow YAML file add this step:
+```yaml
+uses: jesusvasquez333/verify-pr-label-action@v1.2.0
+with:
+    github-token: '${{ secrets.GITHUB_TOKEN }}'
+    valid-labels: 'bug, enhancement'
+    pull-request-number: '${{ github.event.pull_request.number }}'
+```
+
+and trigger it with:
+```yaml
+on:
+  pull_request_target:
+   types: [opened, labeled, unlabeled, synchronize]
+```
+
+### Allowing PR only from the same repository
 
 In your workflow YAML file add this step:
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -17,3 +17,4 @@ runs:
   args:
     - ${{ inputs.github-token }}
     - ${{ inputs.valid-labels }}
+    - ${{ github.event.pull_request.number }}

--- a/action.yml
+++ b/action.yml
@@ -17,4 +17,4 @@ runs:
   args:
     - ${{ inputs.github-token }}
     - ${{ inputs.valid-labels }}
-    - ${{ github.event.pull_request.number }}
+    - ${{ inputs.pull_request_number }}

--- a/action.yml
+++ b/action.yml
@@ -11,10 +11,13 @@ inputs:
   valid-labels:
     description: 'List of valid labels'
     required: true
+  pull-request-number:
+    description: 'The Pull Request number'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.github-token }}
     - ${{ inputs.valid-labels }}
-    - ${{ inputs.pull_request_number }}
+    - ${{ inputs.pull-request-number }}

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -67,7 +67,7 @@ if github_event_name == 'pull_request_target':
         pr_number=int(pr_number_str)
     except ValueError:
         print(f'A valid pull request number input must be defined when triggering on ' \
-            '"pull_request_target".')
+            '"pull_request_target". The pull request number passed was {pr_number_str}.')
         raise
 else:
     # Try to extract the pull request number from the GitHub reference.

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -67,7 +67,7 @@ if github_event_name == 'pull_request_target':
         pr_number=int(pr_number_str)
     except ValueError:
         print(f'A valid pull request number input must be defined when triggering on ' \
-            '"pull_request_target". The pull request number passed was {pr_number_str}.')
+            f'"pull_request_target". The pull request number passed was {pr_number_str}.')
         raise
 else:
     # Try to extract the pull request number from the GitHub reference.
@@ -75,7 +75,7 @@ else:
         pr_number=int(re.search('refs/pull/([0-9]+)/merge', github_ref).group(1))
     except AttributeError:
         print(f'The pull request number could not be extracted from the GITHUB_REF = ' \
-            '"{github_ref}"')
+            f'"{github_ref}"')
         raise
 
 print(f'Pull request number: {pr_number}')

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -28,6 +28,11 @@ def get_env_var(env_var_name, echo_value=False):
 
     return value
 
+print('====ENV====')
+for k,v in os.environ.items():
+    print(f'{k} = {v}')
+print('===========')
+
 # Check if the number of input arguments is correct
 if len(sys.argv) != 3:
     raise ValueError('Invalid number of arguments!')

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -42,6 +42,8 @@ print(f'Valid labels are: {valid_labels}')
 # Get needed values from the environmental variables
 repo_name=get_env_var('GITHUB_REPOSITORY')
 github_ref=get_env_var('GITHUB_REF')
+print(f'GITHUB_REPOSITORY = {repo_name}')
+print(f'GITHUB_REF        = {github_ref}')
 
 # Create a repository object, using the GitHub token
 repo = Github(token).get_repo(repo_name)

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -83,6 +83,12 @@ print(f'Pull request number: {pr_number}')
 # Create a pull request object
 pr = repo.get_pull(pr_number)
 
+# Check if the PR comes from a fork. If so, the trigger must be 'pull_request_target'.
+# Otherwise raise an exception here.
+if pr.head.repo.full_name != pr.base.repo.full_name:
+    if github_event_name != 'pull_request_target':
+        raise Exception(f'PRs from forks are only supported when trigger on "pull_request_target"')
+
 # Get the pull request labels
 pr_labels = pr.get_labels()
 

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -28,11 +28,6 @@ def get_env_var(env_var_name, echo_value=False):
 
     return value
 
-print('====ENV====')
-for k,v in os.environ.items():
-    print(f'{k} = {v}')
-print('===========')
-
 # Check if the number of input arguments is correct
 if len(sys.argv) != 4:
     raise ValueError('Invalid number of arguments!')
@@ -51,9 +46,6 @@ pr_number_str=sys.argv[3]
 repo_name=get_env_var('GITHUB_REPOSITORY')
 github_ref=get_env_var('GITHUB_REF')
 github_event_name=get_env_var('GITHUB_EVENT_NAME')
-print(f'GITHUB_REPOSITORY = {repo_name}')
-print(f'GITHUB_REF        = {github_ref}')
-print(f'GITHUB_EVENT_NAME = {github_event_name}')
 
 # Create a repository object, using the GitHub token
 repo = Github(token).get_repo(repo_name)

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -67,7 +67,7 @@ if github_event_name == 'pull_request_target':
         pr_number=int(pr_number_str)
     except ValueError:
         print(f'A valid pull request number input must be defined when triggering on ' \
-            f'"pull_request_target". The pull request number passed was {pr_number_str}.')
+            f'"pull_request_target". The pull request number passed was "{pr_number_str}".')
         raise
 else:
     # Try to extract the pull request number from the GitHub reference.

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -66,15 +66,17 @@ if github_event_name == 'pull_request_target':
     try:
         pr_number=int(pr_number_str)
     except ValueError:
-        raise ValueError(f'A valid pull request number input must be defined when triggering on \
-            "pull_request_target". The pull request number passed was {pr_number_str}.')
+        print(f'A valid pull request number input must be defined when triggering on ' \
+            '"pull_request_target".')
+        raise
 else:
     # Try to extract the pull request number from the GitHub reference.
     try:
         pr_number=int(re.search('refs/pull/([0-9]+)/merge', github_ref).group(1))
     except AttributeError:
-        raise ValueError(f'The pull request number could not be extracted from the GITHUB_REF = \
-            {github_ref}')
+        print(f'The pull request number could not be extracted from the GITHUB_REF = ' \
+            '"{github_ref}"')
+        raise
 
 print(f'Pull request number: {pr_number}')
 

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -34,7 +34,7 @@ for k,v in os.environ.items():
 print('===========')
 
 # Check if the number of input arguments is correct
-if len(sys.argv) != 3:
+if len(sys.argv) != 4:
     raise ValueError('Invalid number of arguments!')
 
 # Get the GitHub token
@@ -43,6 +43,10 @@ token=sys.argv[1]
 # Get the list of valid labels
 valid_labels=sys.argv[2]
 print(f'Valid labels are: {valid_labels}')
+
+# Get the PR number
+prn=sys.argv[3]
+print(f'Pull request number: {prn}')
 
 # Get needed values from the environmental variables
 repo_name=get_env_var('GITHUB_REPOSITORY')


### PR DESCRIPTION
This resolves #9.

The previous version didn't work when opening PRs from forks due to Github actions running with read-only permissions from forks. 

Fortunately, Github recently added a new trigger event `pull_request_target` which behaves in an almost identical way to the `pull_request` event, but the action runs in the base of the pull request and will therefore have write permission. 

However, as the action runs in the base of the pull request, the pull request number is not available in the environmental variables, which the code was using to extract the number automatically. Therefore, to use this new event, a new input argument was added in order to pass the pull request number which is available in the GitHub context `${{ github.event.pull_request.number }}`.

So, for example, to allow PR from forks, in your workflow YAML file you should trigger with:
```yaml
on:
  pull_request_target:
   types: [opened, labeled, unlabeled, synchronize]
```
and use these steps (you just need to add the extra `pull-request-number` input):
```yaml
uses: jesusvasquez333/verify-pr-label-action@v1.3.0
with:
    github-token: '${{ secrets.GITHUB_TOKEN }}'
    valid-labels: 'bug, enhancement'
    pull-request-number: '${{ github.event.pull_request.number }}'
```

The changes are backward compatibles, so you can still use the `pull_request` tigger event, and in that case you don't need to specify the input `pull-request-number` as you did before. This however won't work with PRs from forks.
