### PR TITLE
Option to disable PR reviews being posted

### DIFF
--- a/.github/workflows/verify-pr-labels.yml
+++ b/.github/workflows/verify-pr-labels.yml
@@ -21,3 +21,4 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           valid-labels: 'bug, enhancement'
           pull-request-number: '${{ github.event.pull_request.number }}'
+          disable-reviews: false

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Depending on the trigger condition used, this input is:
 *   **Required** when the action is triggered using `pull_request_target`. It is available in the github context as: `${{ github.event.pull_request.number }}`. Or,
 *   **Optional** when the action is triggered using `pull_request`. In this case this number is is automatically extracted from the environmental variables.
 
+### `disable-reviews`
+
+**Optional** Set to `true` to have the action skip the approval posting step and return a failure exit status code instead. 
+
 ## Example usage
 
 ### If you want to allow PRs from forks

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,9 @@ inputs:
   pull-request-number:
     description: 'The Pull Request number'
     required: false
+  disable-reviews:
+    description: 'Should the action post reviews on PRs'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -26,3 +29,4 @@ runs:
     - ${{ inputs.valid-labels }}
     - ${{ inputs.invalid-labels }}
     - ${{ inputs.pull-request-number }}
+    - ${{ inputs.disable-reviews }}

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -196,9 +196,10 @@ for review in pr_reviews.reversed:
 # First, we check if there are invalid labels, and generate a review if needed.
 if pr_invalid_labels:
     print('Error! This pull request contains the following invalid labels: '
-          f'{pr_invalid_labels}')
+          f'{pr_invalid_labels}', file=sys.stderr)
 
     if pr_reviews_disabled:
+        print('Exiting with an error code')
         exit(1)
 
     # If there has been already a request for changes due to the presence of
@@ -217,9 +218,10 @@ else:
 # This is done independently of the presence of invalid labels above.
 if not pr_valid_labels:
     print('Error! This pull request does not contain any of the valid labels: '
-          f'{valid_labels}')
+          f'{valid_labels}', file=sys.stderr)
 
     if pr_reviews_disabled:
+        print('Exiting with an error code')
         exit(1)
 
     # If there has been already a request for changes due to missing a valid
@@ -241,6 +243,7 @@ if not pr_invalid_labels and pr_valid_labels:
     print('All labels are OK in this pull request')
 
     if pr_reviews_disabled:
+        print('Exiting without an error code')
         exit(0)
 
     # If the latest review done was approved, then don't approved it again.

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import re
+import distutils.util
 from github import Github
 
 
@@ -39,7 +40,7 @@ def get_env_var(env_var_name, echo_value=False):
 
 
 # Check if the number of input arguments is correct
-if len(sys.argv) != 5:
+if len(sys.argv) != 6:
     print('ERROR: Invalid number of arguments!', file=sys.stderr)
     sys.exit(1)
 
@@ -59,6 +60,13 @@ print(f'Invalid labels are: {invalid_labels}')
 
 # Get the PR number
 pr_number_str = sys.argv[4]
+
+# Are reviews disabled?
+try:
+    pr_reviews_disabled = bool(distutils.util.strtobool(sys.argv[5]))
+except ValueError:
+    pr_reviews_disabled = False
+print(f"PR reviews are: {'disabled' if pr_reviews_disabled else 'enabled'}")
 
 # Get needed values from the environmental variables
 repo_name = get_env_var('GITHUB_REPOSITORY')
@@ -190,6 +198,9 @@ if pr_invalid_labels:
     print('Error! This pull request contains the following invalid labels: '
           f'{pr_invalid_labels}')
 
+    if pr_reviews_disabled:
+        exit(1)
+
     # If there has been already a request for changes due to the presence of
     # invalid labels, then we don't request changes again.
     if review_invalid_label:
@@ -208,6 +219,9 @@ if not pr_valid_labels:
     print('Error! This pull request does not contain any of the valid labels: '
           f'{valid_labels}')
 
+    if pr_reviews_disabled:
+        exit(1)
+
     # If there has been already a request for changes due to missing a valid
     # label, then don't request changes again.
     if review_missing_label:
@@ -225,6 +239,9 @@ else:
 # This condition is complimentary to the other two conditions above.
 if not pr_invalid_labels and pr_valid_labels:
     print('All labels are OK in this pull request')
+
+    if pr_reviews_disabled:
+        exit(0)
 
     # If the latest review done was approved, then don't approved it again.
     if last_review_approved:


### PR DESCRIPTION
@jesusvasquez333 Fixes https://github.com/jesusvasquez333/verify-pr-label-action/issues/20 by adding a workflow option to skip the review step and instead return an error code.

You can see it in action here https://github.com/Pezmc/verify-pr-label-action/pull/3