### PR TITLE
Improve exception handling 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,8 @@ RUN pip3 install pygithub==1.47
 
 COPY verify_pr_lables.py /verify_pr_lables.py
 
+# Force stdin, stdout and stderr to be totally unbuffered.
+# This warranty the order of output messages send to the console
+ENV PYTHONUNBUFFERED 1
+
 ENTRYPOINT ["/verify_pr_lables.py"]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Fortunately, Github recently added a new trigger event `pull_request_target` whi
 
 ### `pull-request-number`
 
-**Optional** The pull request number, available in the github context: `${{ github.event.pull_request.number }}`. This number is automatically extracted from the environmental variables when the action triggers on `pull_request`. However, when the trigger used is `pull_request_target`, then this input must be used.
+Depending on the trigger condition used, this input is:
+* **Required** when the action is triggered using `pull_request_target`. It is available in the github context as: `${{ github.event.pull_request.number }}`. Or,
+* **Optional** when the action is triggered using `pull_request`. In this case this number is is automatically extracted from the environmental variables.
 
 ## Example usage
 

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -41,6 +41,9 @@ if len(sys.argv) != 5:
 
 # Get the GitHub token
 token=sys.argv[1]
+if not token:
+    print('A token must be provided!')
+    sys.exit(1)
 
 # Get the list of valid labels
 valid_labels = [label.strip() for label in sys.argv[2].split(',')]

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -26,7 +26,7 @@ def get_env_var(env_var_name, echo_value=False):
     value=os.environ.get(env_var_name)
 
     if value is None:
-        print(f'The environmental variable {env_var_name} is empty!')
+        print(f'ERROR: The environmental variable {env_var_name} is empty!', file=sys.stderr)
         sys.exit(1)
 
     if echo_value:
@@ -36,13 +36,13 @@ def get_env_var(env_var_name, echo_value=False):
 
 # Check if the number of input arguments is correct
 if len(sys.argv) != 5:
-    print('Invalid number of arguments!')
+    print('ERROR: Invalid number of arguments!', file=sys.stderr)
     sys.exit(1)
 
 # Get the GitHub token
 token=sys.argv[1]
 if not token:
-    print('A token must be provided!')
+    print('ERROR: A token must be provided!', file=sys.stderr)
     sys.exit(1)
 
 # Get the list of valid labels
@@ -72,16 +72,17 @@ if github_event_name == 'pull_request_target':
     try:
         pr_number=int(pr_number_str)
     except ValueError:
-        print(f'A valid pull request number input must be defined when triggering on ' \
-            f'"pull_request_target". The pull request number passed was "{pr_number_str}".')
+        print(f'ERROR: A valid pull request number input must be defined when triggering on ' \
+            f'"pull_request_target". The pull request number passed was "{pr_number_str}".',
+            file=sys.stderr)
         sys.exit(1)
 else:
     # Try to extract the pull request number from the GitHub reference.
     try:
         pr_number=int(re.search('refs/pull/([0-9]+)/merge', github_ref).group(1))
     except AttributeError:
-        print(f'The pull request number could not be extracted from the GITHUB_REF = ' \
-            f'"{github_ref}"')
+        print(f'ERROR: The pull request number could not be extracted from the GITHUB_REF = ' \
+            f'"{github_ref}"', file=sys.stderr)
         sys.exit(1)
 
 print(f'Pull request number: {pr_number}')
@@ -93,7 +94,8 @@ pr = repo.get_pull(pr_number)
 # Otherwise exit on error here.
 if pr.head.repo.full_name != pr.base.repo.full_name:
     if github_event_name != 'pull_request_target':
-        print('PRs from forks are only supported when trigger on "pull_request_target"')
+        print('ERROR: PRs from forks are only supported when trigger on "pull_request_target"',
+            file=sys.stderr)
         sys.exit(1)
 
 # Get the pull request labels

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -43,11 +43,11 @@ if len(sys.argv) != 5:
 token=sys.argv[1]
 
 # Get the list of valid labels
-valid_labels=sys.argv[2]
+valid_labels = [label.strip() for label in sys.argv[2].split(',')]
 print(f'Valid labels are: {valid_labels}')
 
 # Get the list of invalid labels
-invalid_labels=sys.argv[3]
+invalid_labels = [label.strip() for label in sys.argv[3].split(',')]
 print(f'Invalid labels are: {invalid_labels}')
 
 # Get the PR number

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -26,7 +26,8 @@ def get_env_var(env_var_name, echo_value=False):
     value=os.environ.get(env_var_name)
 
     if value is None:
-        raise ValueError(f'The environmental variable {env_var_name} is empty!')
+        print(f'The environmental variable {env_var_name} is empty!')
+        sys.exit(1)
 
     if echo_value:
         print(f"{env_var_name} = {value}")
@@ -35,7 +36,8 @@ def get_env_var(env_var_name, echo_value=False):
 
 # Check if the number of input arguments is correct
 if len(sys.argv) != 5:
-    raise ValueError('Invalid number of arguments!')
+    print('Invalid number of arguments!')
+    sys.exit(1)
 
 # Get the GitHub token
 token=sys.argv[1]
@@ -85,10 +87,11 @@ print(f'Pull request number: {pr_number}')
 pr = repo.get_pull(pr_number)
 
 # Check if the PR comes from a fork. If so, the trigger must be 'pull_request_target'.
-# Otherwise raise an exception here.
+# Otherwise exit on error here.
 if pr.head.repo.full_name != pr.base.repo.full_name:
     if github_event_name != 'pull_request_target':
-        raise Exception('PRs from forks are only supported when trigger on "pull_request_target"')
+        print('PRs from forks are only supported when trigger on "pull_request_target"')
+        sys.exit(1)
 
 # Get the pull request labels
 pr_labels = pr.get_labels()

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -69,7 +69,7 @@ if github_event_name == 'pull_request_target':
     except ValueError:
         print(f'A valid pull request number input must be defined when triggering on ' \
             f'"pull_request_target". The pull request number passed was "{pr_number_str}".')
-        raise
+        sys.exit(1)
 else:
     # Try to extract the pull request number from the GitHub reference.
     try:
@@ -77,7 +77,7 @@ else:
     except AttributeError:
         print(f'The pull request number could not be extracted from the GITHUB_REF = ' \
             f'"{github_ref}"')
-        raise
+        sys.exit(1)
 
 print(f'Pull request number: {pr_number}')
 


### PR DESCRIPTION
This PR removed the raise of exceptions to avoid generating stack tracebacks on the console output. Instead, error messages are printed and the script exits on an error code. Error messages are also prefixed with `ERROR:` for clarify, and they are send to `stderr`. `stdin`, `stdout` and `stderr` are forced to be totally unbuffered, to preserve the order of messages in the logs.

The handling of input argument is improved as well. The scripts makes sure that the GitHub token is not empty, and the list of labels are converted to python list, using `,` as delimiter and stripping white spaces.

Additionally, this PR clarifies the use of the `pull-request-numer` input, which is mandatory when the action is trigger using `pull_request_target`.

This resolves #19 