### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Depending on the trigger condition used, this input is:
 
 ### `disable-reviews`
 
-**Optional** Set to `true` to disable the creation on pull request reviews, and use the exit code instead.
+**Optional** Set to `true` to disable the creation on pull request reviews, and use the status of the check instead.
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,23 @@
 
 This action will verify if a pull request has at least one label from a set of valid labels, as well as no label from a set of invalid labels. The sets of valid and invalid labels are defined by the user and passed as input arguments.
 
-If the pull request does not contain a label from the set of valid labels, or contains a label from the set of invalid labels, then the action will create a pull request review using the event `REQUEST_CHANGES`; independent reviews are generated for both cases. Otherwise, the action will instead create a pull request review using the event `APPROVE`. In both of these cases the exit code will be `0`, and the GitHub check will succeed.
+To prevent the merging of an invalid pull request, this action uses either the standard pull request workflow or the status of the GitHub Action check.
 
-This action uses the pull request workflow to prevent the merging of a pull request without a valid label or with an invalid label, instead of the status of the GitHub checks. The reason for this is that GitHub workflows will run independent checks for different trigger conditions, instead of grouping them together. For example, consider that the action is triggered by `pull_request`'s types `opened` and `labeled`, then if a pull request is opened without adding a valid label at the time of creation, that event will trigger a check that should fail; however, adding later a valid label to the pull request will just trigger a **new** check which will succeed, but the first check will remain in the failed state (and the pull request merge will be blocked if the option `Require status checks to pass before merging` is enabled in the repository).
+### Using the standard pull request workflow
 
-Instead, consider the same example, the action is triggered by `pull_request`'s types `opened` and `labeled`, then if a pull request is opened without adding a valid label at the time of creation, that event will trigger a check that will succeed, but will crate a pull request review, requesting for changes. The pull request review will prevent the merging of the pull request (if the option `Require pull request reviews before merging` is enabled in the repository) in this case. Adding a valid label to the repository will then trigger a **new** action which will succeed as well, but in this case it will create a new pull request review, approving the pull request. After this, the pull request can be merged.
+By default, this action uses the standard pull request workflow. In this mode, if the pull request does not contain a label from the set of valid labels, or contains a label from the set of invalid labels, then the action will create a pull request review using the event `REQUEST_CHANGES`; independent reviews are generated for both cases. Otherwise, the action will instead create a pull request review using the event `APPROVE`. In both of these cases the exit code will be `0`, and the GitHub Action check will always succeed.
+
+The `REQUEST_CHANGES` review will prevent the merging of the pull request (if the option `Require pull request reviews before merging` is enabled in the repository) until the `APPROVE` review is generated. After that, the pull request can be merged.
 
 When this action runs, it will look for the previous review done by itself, and it will not repeat the same request again. However, if the option `Dismiss stale pull request approvals when new commits are pushed` is enabled in the repository, previous review will be automatically dismissed and therefore this check will fail, and a new request will always be generated.
 
 **Note**: if you want to use the `Require pull request reviews before merging` to require reviews approval before merging pull requests, then you need to increase the number of `Required approving reviewers` by one, as this check will do an approval when a valid label is present. So, for example, if you want at least one reviewer approval, then set this value to 2.
+
+### Using the GitHub Action check status
+
+On the other hand, the creations of reviews can be disabled by setting the input `disable-reviews` to `true`. In this mode, if the pull request does not contain a label from the set of valid labels, or contains a label from the set of invalid labels, then the action will exit with an error code (`1`), and the GitHub Action check will fail. Otherwise, the action will instead exit with the code `0`, and the GitHub Action check will succeed. In both cases, the action won't create any pull request review.
+
+The failing of the GitHub Action check will prevent the merging of the pull request (if the option `Require status checks to pass before merging` is enabled in the repository) until the check succeeds. After that, the pull request can be merged.
 
 ## Note when working with forks
 
@@ -44,7 +52,7 @@ Depending on the trigger condition used, this input is:
 
 ### `disable-reviews`
 
-**Optional** Set to `true` to have the action skip the approval posting step and return a failure exit status code instead.
+**Optional** Set to `true` to disable the creation on pull request reviews, and use the exit code instead.
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -44,13 +44,11 @@ Depending on the trigger condition used, this input is:
 
 ### `disable-reviews`
 
-**Optional** Set to `true` to have the action skip the approval posting step and return a failure exit status code instead. 
+**Optional** Set to `true` to have the action skip the approval posting step and return a failure exit status code instead.
 
 ## Example usage
 
-### If you want to allow PRs from forks
-
-If you want to allow PRs from anywhere, including forks, then you can use this example. These instructions will work even if you are not going to work with forks.
+Normally, in your project you would want to allow PRs both from the same repository as well as forks. In that case, you must use the trigger condition `pull_request_target`, as described in this example:
 
 In your workflow YAML file add these steps:
 ```yaml
@@ -69,9 +67,7 @@ on:
    types: [opened, labeled, unlabeled, synchronize]
 ```
 
-### If you plan to only open PRs from the same repository
-
-If you plan to open PR only from the same repository, you can use this example, which requires one less input value. However, this won't work if you open a PR from a fork.
+The above example should you preferred method. Nevertheless, the trigger condition `pull_request` is also supported, and you can use it instead of `pull_request_target`. This condition, however, works only for PRs from the same repository; its only advantage is that the `pull-request-number` input is not needed in this case and can be omitted. So, if you want to use that condition instead, follow this example:
 
 In your workflow YAML file add this step:
 ```yaml
@@ -88,3 +84,5 @@ on:
   pull_request:
    types: [opened, labeled, unlabeled, synchronize]
 ```
+
+Please note that you must use only **one** trigger condition for your action, either `pull_request_target` or `pull_request`, but not both at the same time.


### PR DESCRIPTION
This PR updates the documentation to:
- Clarify the use case of the two supported trigger conditions (`pull_request_target` and `pull_request`). This resolves #18 .
- Describe the new feature where reviews are disabled, and the status of the check is used instead