### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Depending on the trigger condition used, this input is:
 
 ### `disable-reviews`
 
-**Optional** Set to `true` to disable the creation on pull request reviews, and use the status of the check instead.
+**Optional** Set to `true` to disable the creation of pull request reviews, and use the status of the check instead.
 
 ## Example usage
 


### PR DESCRIPTION
I think in the README.md this should read "_disable the creation of pull request reviews_".